### PR TITLE
Adicionar exceção para aresta duplicada.

### DIFF
--- a/py_graph_t/SimpleGraph.py
+++ b/py_graph_t/SimpleGraph.py
@@ -1,7 +1,7 @@
 from .vertex.SimpleVertex import SimpleVertex
 from .edges.SimpleEdge import SimpleEdge
 
-from .exceptions.SimpleGraphException import VertexNotExistsException, VertexDuplicatedException
+from .exceptions.SimpleGraphException import VertexNotExistsException, EdgeDuplicatedException
 
 class SimpleGraph():
     """Implementação de um simples grafo."""
@@ -67,7 +67,7 @@ class SimpleGraph():
         if (vertex_a == None or vertex_b == None):
             raise VertexNotExistsException()
         if SimpleEdge(name=name, vertex_a=vertex_a, vertex_b=vertex_b) in self.edges:
-            raise VertexDuplicatedException()
+            raise EdgeDuplicatedException()
         else:
             self.edges.append(SimpleEdge( name=name, vertex_a=vertex_a, vertex_b=vertex_b))
 

--- a/py_graph_t/SimpleGraph.py
+++ b/py_graph_t/SimpleGraph.py
@@ -1,7 +1,7 @@
 from .vertex.SimpleVertex import SimpleVertex
 from .edges.SimpleEdge import SimpleEdge
 
-from .exceptions.SimpleGraphException import VertexNotExistsException
+from .exceptions.SimpleGraphException import VertexNotExistsException, VertexDuplicatedException
 
 class SimpleGraph():
     """Implementação de um simples grafo."""
@@ -66,6 +66,8 @@ class SimpleGraph():
 
         if (vertex_a == None or vertex_b == None):
             raise VertexNotExistsException()
+        if SimpleEdge(name=name, vertex_a=vertex_a, vertex_b=vertex_b) in self.edges:
+            raise VertexDuplicatedException()
         else:
             self.edges.append(SimpleEdge( name=name, vertex_a=vertex_a, vertex_b=vertex_b))
 

--- a/py_graph_t/exceptions/SimpleGraphException.py
+++ b/py_graph_t/exceptions/SimpleGraphException.py
@@ -4,6 +4,6 @@ class VertexNotExistsException(Exception):
         return "Vértice não existe"
 
 
-class VertexDuplicatedException(Exception):
+class EdgeDuplicatedException(Exception):
     def __str__(self):
-        return "Vértice Duplicado"
+        return "Aresta Duplicada"

--- a/py_graph_t/exceptions/SimpleGraphException.py
+++ b/py_graph_t/exceptions/SimpleGraphException.py
@@ -2,3 +2,8 @@
 class VertexNotExistsException(Exception):
     def __str__(self):
         return "Vértice não existe"
+
+
+class VertexDuplicatedException(Exception):
+    def __str__(self):
+        return "Vértice Duplicado"


### PR DESCRIPTION
Verifica se na inserção da aresta se o par de vértices não possui uma aresta ligando-os, caso possua, lança uma exceção. #25 