### PR TITLE
order dependent tests fix

### DIFF
--- a/__tests__/test_simple_graph.py
+++ b/__tests__/test_simple_graph.py
@@ -9,26 +9,40 @@ from ..py_graph_t.exceptions.SimpleGraphException import (
 
 class TestSimpleGraph:
     graph = SimpleGraph()
+    neighbors_true = []
+ 
+    def setup_method(self):
+        self.graph = SimpleGraph()
+        self.neighbors_true = []
+        self.graph.add_vertex("a")
+        self.graph.add_vertex("b")
+        self.graph.add_edge("a", "b", "ab")
+        for x in range(10):
+            self.graph.add_vertex(str(x))
+        for x in range(1, 5):
+            self.neighbors_true.append(self.graph.vertices[str(x)])
+            self.graph.add_edge("0", str(x), "x")
 
     def test_num_vertex(self):
-        self.graph.add_vertex("a")
-        assert self.graph.num_vertex() == 1
+        assert self.graph.num_vertex() == 12
 
     def test_add_vertex(self):
-        value = "b"
+        value = "f"
         vertex = self.graph.add_vertex(value)
-        assert str(vertex) == 'Vértice b'
+        assert str(vertex) == 'Vértice f'
 
     def test_delete_vertex(self):
         vertex_delete = self.graph.delete_vertex("a")
-        assert self.graph.num_vertex() == 1
+        assert self.graph.num_vertex() == 11
         assert str(vertex_delete) == "Vértice a"
 
+
     def test_is_terminal(self):
-        self.graph.add_vertex("a")
-        edge = self.graph.add_edge("a", "b", "ab")
-        assert self.graph.is_terminal(edge, 'a') and \
-            self.graph.is_terminal(edge, 'b')
+        self.graph.add_vertex("j")
+        self.graph.add_vertex("k")
+        edge = self.graph.add_edge("j", "k", "jk")
+        assert self.graph.is_terminal(edge, 'j') and \
+            self.graph.is_terminal(edge, 'k')
 
     def test_vertex_exists(self):
         assert self.graph.vertex_exists("a")
@@ -37,16 +51,10 @@ class TestSimpleGraph:
         assert self.graph.edge_exists("a", "b")
 
     def test_num_edges(self):
-        assert self.graph.num_edges() == 1
+        assert self.graph.num_edges() == 5
 
     def test_vertex_neighbors(self):
-        neighbors_true = []
-        for x in range(10):
-            self.graph.add_vertex(str(x))
-        for x in range(1, 5):
-            neighbors_true.append(self.graph.vertices[str(x)])
-            self.graph.add_edge("0", str(x), "x")
-        assert self.graph.vertex_neighbors("0") == neighbors_true
+        assert self.graph.vertex_neighbors("0") == self.neighbors_true
 
     def test_vertex_degree(self):
         assert len(self.graph.vertex_neighbors("b")) == 1
@@ -57,8 +65,8 @@ class TestSimpleGraph:
         assert vertex_b in neighbors_vertices
 
     def test_get_all_vertex(self):
-        assert str(self.graph.get_all_vertex()) == "{'b': Vértice b, " + \
-            "'a': Vértice a, '0': Vértice 0, '1': Vértice 1, " + \
+        assert str(self.graph.get_all_vertex()) == "{'a': Vértice a, " + \
+            "'b': Vértice b, '0': Vértice 0, '1': Vértice 1, " + \
             "'2': Vértice 2, '3': Vértice 3, '4': Vértice 4, " + \
             "'5': Vértice 5, '6': Vértice 6, '7': Vértice 7, " + \
             "'8': Vértice 8, '9': Vértice 9}"
@@ -68,7 +76,7 @@ class TestSimpleGraph:
         for vertex in self.graph.vertices:
             vertices.append(vertex)
         assert str(self.graph.list_graph_vertices()) == \
-            "['b', 'a', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']"
+            "['a', 'b', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']"
 
     def test_list_graph_edges(self):
         edges = []
@@ -89,6 +97,9 @@ class TestSimpleGraph:
         assert self.graph.has_loop() is False
 
     def test_false_cycle_graph(self):
+        self.graph.add_vertex("c")
+        self.graph.add_edge("b", "c", 2)
+        self.graph.add_edge("c", "a", 3)
         self.graph.delete_edge("c", "a")
         self.graph.add_vertex("d")
         self.graph.add_edge("c", "d", 3)
@@ -101,6 +112,12 @@ class TestSimpleGraph:
         assert self.graph.has_loop() is False
 
     def test_true_regular_graph(self):
+        self.graph.add_vertex("c")
+        self.graph.add_edge("b", "c", 2)
+        self.graph.add_edge("c", "a", 3)
+        self.graph.delete_edge("c", "a")
+        self.graph.add_vertex("d")
+        self.graph.add_edge("c", "d", 3)
         self.graph.delete_vertex("d")
         for i in range(0, 10):
             self.graph.delete_vertex(str(i))
@@ -112,9 +129,22 @@ class TestSimpleGraph:
         assert self.graph.check_regular_graph() is True
 
     def test_false_regular_graph(self):
+        self.graph.add_vertex("c")
+        self.graph.add_edge("b", "c", 2)
+        self.graph.add_edge("c", "a", 3)
+        self.graph.delete_edge("c", "a")
+        self.graph.add_vertex("d")
+        self.graph.add_edge("c", "d", 3)
+        self.graph.delete_vertex("d")
+        for i in range(0, 10):
+            self.graph.delete_vertex(str(i))
+
+        self.graph.add_vertex("d")
+        self.graph.delete_edge("b", "c")
+        self.graph.add_edge("c", "d", 3)
         self.graph.add_edge("b", "c", 3)
         assert self.graph.check_regular_graph() is False
 
     def test_duplicated_edge(self):
         with pytest.raises(EdgeDuplicatedException):
-            assert self.graph.add_edge("b", "c")
+            assert self.graph.add_edge("a", "b")


### PR DESCRIPTION
--Sorry I only speak English and cannot fully understand the pr requirement--
The test is based on the report generated by pytest flake-finder
you can run
```
pytest --flake-finder 
```
And there are 441 tests that failed with 100 runs by default in test_simple_graph.py.
These flaky tests are caused by order-dependent from each test. My improvement is trying to have a pre-setup before each test. Although I would recommend a further improvement by separate tests to classes.
Currently, after my improvement, all tests pass under both run pytest and pytest flakefinder.
